### PR TITLE
Replace IPv4-only host with dual stack bind

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -39,4 +39,4 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
 CMD ["python", "docker_start.py"]
 
 # Alternative production command with Gunicorn (uncomment for production)
-# CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "4", "docker_start:app"]
+# CMD ["gunicorn", "--bind", "[::]:5000", "--workers", "4", "docker_start:app"]

--- a/api/app.py
+++ b/api/app.py
@@ -159,9 +159,9 @@ if __name__ == "__main__":
     # Use Railway's PORT or default to 5000
     port = int(os.getenv("PORT", 5000))
     print(f"Starting server on port: {port}")
-    print(f"Host: {'0.0.0.0' if env == 'production' else '127.0.0.1'}")
+    print(f"Host: {'[::]' if env == 'production' else '127.0.0.1'}")
 
     if env == "production":
-        app.run(host="0.0.0.0", port=port, debug=False)
+        app.run(host="::", port=port, debug=False)
     else:
         app.run(debug=True, host="127.0.0.1", port=port)

--- a/api/debug_railway.py
+++ b/api/debug_railway.py
@@ -31,9 +31,9 @@ try:
 
     port = int(os.getenv("PORT", 8080))
     print(f"\n=== STARTING FLASK APP ===")
-    print(f"Attempting to start on 0.0.0.0:{port}")
+    print(f"Attempting to start on [::]:{port}")
 
-    app.run(host="0.0.0.0", port=port, debug=True)
+    app.run(host="::", port=port, debug=True)
 
 except Exception as e:
     print(f"ERROR: Failed to start Flask app: {e}")

--- a/api/docker_start.py
+++ b/api/docker_start.py
@@ -28,4 +28,4 @@ if __name__ == "__main__":
     )
 
     # Run the app
-    app.run(host="0.0.0.0", port=port, debug=False)
+    app.run(host="::", port=port, debug=False)

--- a/api/simple_test.py
+++ b/api/simple_test.py
@@ -30,4 +30,4 @@ def test():
 if __name__ == "__main__":
     port = int(os.getenv("PORT", 5000))
     print(f"Starting simple test app on port {port}")
-    app.run(host="0.0.0.0", port=port, debug=False)
+    app.run(host="::", port=port, debug=False)

--- a/api/start.py
+++ b/api/start.py
@@ -33,4 +33,4 @@ if __name__ == "__main__":
     )
 
     # Run the app
-    app.run(host="0.0.0.0", port=port, debug=False)
+    app.run(host="::", port=port, debug=False)


### PR DESCRIPTION
Use `::` / `[::]` as host to bind the API server to both IPv4 and IPv6 interfaces (`::` is automatically a dual stack binding in Flask and Gunicorn). Nginx is already configured with only a port so it should be binding to both IPv4 and IPv6 automatically (though I haven't needed to test this).

I think that in future there should probably be an env var for defining the bind address (host and port) as well.

Note that I personally needed this because Railway's internal network is IPv6-only: https://docs.railway.com/guides/private-networking#listen-on-ipv6

