### PR TITLE
Allow configuring API URL and port in frontend through env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,12 @@ FROM nginx:stable-bookworm
 COPY --from=build /app/dist /usr/share/nginx/html
 
 # Copy nginx configuration
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+
+# Set configuration env vars that can be passed to nginx and their default values
+ENV NGINX_ENVSUBST_FILTER="API_URL|PORT"
+ENV API_URL="http://api:5000"
+ENV PORT=80
 
 # Expose port 80
 EXPOSE 80

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen ${PORT};
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;
@@ -24,7 +24,7 @@ server {
 
     # Proxy API requests to backend
     location /api/ {
-        proxy_pass http://api:5000;
+        proxy_pass ${API_URL};
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
While for a simple pre-provided Docker Compose file, the API URL can be assumed to be `http://api:5000`, this won't be true in all networking setups. In my case, I use Railway, which exposes the internal network under the `railway.internal` subdomain, so I need to be able to change the API URL appropriately. Fly.io does things similarly, and even in some self-hosting scenarios, the domain won't necessarily be just `api` (aside from the fact that someone could choose to name the service differently, I guess).
I also figured I might as well allow configuring the port of the frontend as well.