### PR TITLE
Improve flow for adding new entries

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,10 +80,17 @@ const AppContent = () => {
   };
 
   useEffect(() => {
-    const handler = () => setCurrentView('entry');
+    const handler = () => {
+      if (currentView !== 'history') {
+        setCurrentView('history');
+        return;
+      }
+
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
     window.addEventListener('nightlio:new-entry', handler);
     return () => window.removeEventListener('nightlio:new-entry', handler);
-  }, []);
+  }, [currentView]);
 
   return (
     <>
@@ -167,7 +174,16 @@ const AppContent = () => {
         onLoadStatistics={loadStatistics}
       />
 
-      <FAB onClick={() => handleViewChange("entry")} />
+      <FAB
+        onClick={() => {
+          if (currentView === 'history') {
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+          } else {
+            setCurrentView('history');
+          }
+        }}
+        label="Scroll to top"
+      />
     </>
   );
 };

--- a/src/components/navigation/Sidebar.jsx
+++ b/src/components/navigation/Sidebar.jsx
@@ -1,9 +1,8 @@
-import { Home, BarChart3, Trophy, Settings, PlusCircle, Target } from 'lucide-react';
+import { Home, BarChart3, Trophy, Settings, Target } from 'lucide-react';
 
 const Sidebar = ({ currentView, onViewChange, onLoadStatistics }) => {
   const items = [
     { key: 'history', label: 'Home', icon: Home },
-    { key: 'entry', label: 'New Entry', icon: PlusCircle },
     { key: 'goals', label: 'Goals', icon: Target },
     { key: 'stats', label: 'Statistics', icon: BarChart3 },
     { key: 'achievements', label: 'Achievements', icon: Trophy },


### PR DESCRIPTION
This pull request updates the view switching and user interaction logic in the main app component and sidebar. The changes improve the behavior when switching between views, specifically how the app responds to new entry events and the floating action button (FAB). Additionally, the sidebar navigation is simplified by removing the "New Entry" option.

Fixes #24 

**View Switching and User Interaction:**

* Updated the event handler for `nightlio:new-entry` in `App.jsx` to switch to the `history` view if not already there, and to smoothly scroll to the top if already in the `history` view. The effect now depends on `currentView` for correct behavior.
* Modified the FAB in `App.jsx` to either scroll to the top if already in the `history` view or switch to `history` otherwise. Also added a label "Scroll to top" to the FAB for clarity.

**Navigation Simplification:**

* Removed the "New Entry" navigation item and its icon from the sidebar in `Sidebar.jsx`, reducing clutter and centralizing entry creation to the FAB.