### PR TITLE
Goal rollover at the end of weeks

### DIFF
--- a/api/test_goals_week_rollover.py
+++ b/api/test_goals_week_rollover.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timedelta
+import sqlite3
+
+from api.app import create_app
+
+
+def _week_start_iso(d=None):
+    if d is None:
+        d = datetime.now().date()
+    # Monday as start of the week
+    start = d - timedelta(days=d.weekday())
+    return start.strftime("%Y-%m-%d")
+
+
+def _auth_headers(client):
+    resp = client.post("/api/auth/local/login")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    token = data["token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_goals_reset_on_new_week_list_endpoint(tmp_path):
+    app = create_app("testing")
+    client = app.test_client()
+
+    # Login and create a goal with freq 7
+    headers = _auth_headers(client)
+    resp = client.post(
+        "/api/goals",
+        json={"title": "Daily Walk", "description": "30 mins", "frequency_per_week": 7},
+        headers=headers,
+    )
+    assert resp.status_code in (200, 201)
+    goal_id = resp.get_json().get("id")
+    assert goal_id
+
+    # Mutate DB to simulate last week's state with partial completion (3/7) and period_start last week
+    db_path = app.config.get("DATABASE_PATH") or "/tmp/nightlio_test.db"
+    last_week_monday = _week_start_iso(datetime.now().date() - timedelta(days=7))
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE goals SET completed = ?, period_start = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+            (3, last_week_monday, goal_id),
+        )
+        conn.commit()
+
+    # Fetch goals; backend should rollover to current week (completed back to 0)
+    resp = client.get("/api/goals", headers=headers)
+    assert resp.status_code == 200
+    lst = resp.get_json()
+    assert isinstance(lst, list)
+    g = next((x for x in lst if x["id"] == goal_id), None)
+    assert g is not None
+    assert g["completed"] == 0, "expected completed to reset at new week start"
+    assert g["period_start"] == _week_start_iso()


### PR DESCRIPTION
Fixes #23

This pull request introduces automatic weekly rollover logic for user goals, ensuring that goal progress and streaks are accurately reset at the start of each new week. The main change is the addition of a helper method that updates the goal state if the stored period is from a previous week. This logic is now consistently applied across goal listing, single-goal fetch, and goal progress increment operations. A new test verifies the correct reset behavior on week boundaries.

**Goal rollover logic improvements:**

* Added `_rollover_goal_if_needed` method to `api/database.py` to automatically reset `completed` progress, update `streak`, and set `period_start` for goals when a new week starts. This ensures users see up-to-date goal status without manual intervention.

**API consistency updates:**

* Updated `get_goals`, `get_goal_by_id`, and `increment_goal_progress` methods in `api/database.py` to use the new rollover helper, guaranteeing that all endpoints return goals with current week status. [[1]](diffhunk://#diff-6a0d8c37c66441e7248ec676d7eb0ee364b9f747350c1d71e3f4fdcf448c029eL271-R331) [[2]](diffhunk://#diff-6a0d8c37c66441e7248ec676d7eb0ee364b9f747350c1d71e3f4fdcf448c029eL293-R347) [[3]](diffhunk://#diff-6a0d8c37c66441e7248ec676d7eb0ee364b9f747350c1d71e3f4fdcf448c029eL356-L369)

**Testing enhancements:**

* Added `api/test_goals_week_rollover.py` to verify that goals are correctly reset to zero progress at the start of a new week when fetched via the list endpoint.