### PR TITLE
Change create_group_option route to use correct value from request when adding an option to a category

### DIFF
--- a/api/routes/group_routes.py
+++ b/api/routes/group_routes.py
@@ -17,7 +17,8 @@ def create_group_routes(group_service: GroupService):
     @group_bp.route("/groups", methods=["POST"])
     def create_group():
         try:
-            name = request.json
+            data = request.json
+            name = data.get("name")
 
             if not name:
                 return jsonify({"error": "Group name is required"}), 400
@@ -43,8 +44,7 @@ def create_group_routes(group_service: GroupService):
     @group_bp.route("/groups/<int:group_id>/options", methods=["POST"])
     def create_group_option(group_id):
         try:
-            data = request.json
-            name = data.get("name")
+            name = request.json
 
             if not name:
                 return jsonify({"error": "Option name is required"}), 400


### PR DESCRIPTION
The `create_group_option()` method was raising an exception due to trying to access an object rather than the raw value, preventing it from working.

Fixes #46 