### PR TITLE
Fix environment variable to set build options

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "NODE_OPTIONS='--max-old-space-size=768' vite build",
     "lint": "eslint .",
     "preview": "vite preview",
     "api": "cd api && python3 -m venv venv && venv/bin/pip install -r requirements.txt && venv/bin/flask run --no-debugger",


### PR DESCRIPTION
This pull request makes a minor adjustment to the `build` script in the `package.json` file to help manage memory usage during the build process.

- Updated the `build` script to set `NODE_OPTIONS='--max-old-space-size=768'`, which limits Node.js memory usage to 768MB during the Vite build.