### PR TITLE
Fixed a couple of bugs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,7 +32,7 @@ const AppContent = () => {
   
   // Custom hooks
   const { pastEntries, setPastEntries, loading: historyLoading, error: historyError, refreshHistory } = useMoodData();
-  const { groups, createGroup, createGroupOption } = useGroups();
+  const { groups, createGroup, createGroupOption, deleteGroup } = useGroups();
   const { statistics, currentStreak, loading: statsLoading, error: statsError, loadStatistics } = useStatistics();
 
   const handleMoodSelect = (moodValue) => {
@@ -124,6 +124,7 @@ const AppContent = () => {
                     onBack={handleBackToHistory}
                     onCreateGroup={createGroup}
                     onCreateOption={createGroupOption}
+                    onDeleteGroup={deleteGroup}
                     onEntrySubmitted={handleEntrySubmitted}
                     editingEntry={editingEntry}
                     onEntryUpdated={handleEntryUpdated}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,7 +36,7 @@ const AppContent = () => {
   const { statistics, currentStreak, loading: statsLoading, error: statsError, loadStatistics } = useStatistics();
 
   const handleMoodSelect = (moodValue) => {
-    navigate('entry', { state: { mood: moodValue } });
+    navigate('/dashboard/entry', { state: { mood: moodValue } });
   };
 
   const handleBackToHistory = () => {
@@ -54,7 +54,7 @@ const AppContent = () => {
   };
 
   const handleStartEdit = (entry) => {
-    navigate('entry', { state: { entry: entry, mood: entry.mood } });
+    navigate('/dashboard/entry', { state: { entry: entry, mood: entry.mood } });
   };
 
   const handleEditMoodSelect = (moodValue) => {
@@ -82,6 +82,9 @@ const AppContent = () => {
         navigate('/dashboard');
         return;
       }
+
+      // Navigate to the new entry page
+      navigate('/dashboard/entry');
 
       window.scrollTo({ top: 0, behavior: 'smooth' });
     };
@@ -146,7 +149,7 @@ const AppContent = () => {
               <Route index element={
                 <>
                   <section className="app-wide" aria-label="Goals section">
-                    <GoalsSection onNavigateToGoals={() => navigate('goals')} />
+                    <GoalsSection onNavigateToGoals={() => navigate('/dashboard/goals')} />
                   </section>
                   <section className="app-wide" aria-label="History entries">
                     <h2 style={{ margin: '0 0 var(--space-1) 0', paddingLeft: 'calc(var(--space-1) / 2)', paddingTop: 0, paddingBottom: 'calc(var(--space-1) / 2)', color: 'var(--text)' }}>History</h2>

--- a/src/components/groups/GroupManager.jsx
+++ b/src/components/groups/GroupManager.jsx
@@ -1,13 +1,14 @@
 import { useState } from 'react';
-import { Settings, X } from 'lucide-react';
+import { Settings, X, Trash2 } from 'lucide-react';
 
-const GroupManager = ({ groups, onCreateGroup, onCreateOption }) => {
+const GroupManager = ({ groups, onCreateGroup, onCreateOption, onDeleteGroup }) => {
   const [showManager, setShowManager] = useState(false);
   const [newGroupName, setNewGroupName] = useState('');
   const [newOptionName, setNewOptionName] = useState('');
   const [selectedGroupForOption, setSelectedGroupForOption] = useState('');
   const [isCreatingGroup, setIsCreatingGroup] = useState(false);
   const [isCreatingOption, setIsCreatingOption] = useState(false);
+  const [deletingGroupId, setDeletingGroupId] = useState(null);
 
   const handleCreateGroup = async () => {
     if (!newGroupName.trim()) return;
@@ -25,7 +26,7 @@ const GroupManager = ({ groups, onCreateGroup, onCreateOption }) => {
 
   const handleCreateOption = async () => {
     if (!newOptionName.trim() || !selectedGroupForOption) return;
-    
+
     setIsCreatingOption(true);
     try {
       const success = await onCreateOption(selectedGroupForOption, newOptionName.trim());
@@ -35,6 +36,19 @@ const GroupManager = ({ groups, onCreateGroup, onCreateOption }) => {
       }
     } finally {
       setIsCreatingOption(false);
+    }
+  };
+
+  const handleDeleteGroup = async (groupId) => {
+    if (!window.confirm('Are you sure you want to delete this category? This action cannot be undone.')) {
+      return;
+    }
+
+    setDeletingGroupId(groupId);
+    try {
+      await onDeleteGroup(groupId);
+    } finally {
+      setDeletingGroupId(null);
     }
   };
 
@@ -75,6 +89,8 @@ const GroupManager = ({ groups, onCreateGroup, onCreateOption }) => {
         padding: '1.5rem',
     boxShadow: 'var(--shadow-lg)',
         marginTop: '1rem',
+        maxHeight: '70vh',
+        overflowY: 'auto',
       }}
     >
       <div
@@ -232,13 +248,40 @@ const GroupManager = ({ groups, onCreateGroup, onCreateOption }) => {
                   background: 'var(--surface)',
                   borderRadius: '8px',
                   border: '1px solid var(--border)',
+                  position: 'relative',
                 }}
               >
+                <button
+                  onClick={() => handleDeleteGroup(group.id)}
+                  disabled={deletingGroupId === group.id}
+                  style={{
+                    position: 'absolute',
+                    top: '0.5rem',
+                    right: '0.5rem',
+                    background: 'transparent',
+                    border: 'none',
+                    cursor: deletingGroupId === group.id ? 'not-allowed' : 'pointer',
+                    color: 'var(--text-muted)',
+                    padding: '0.25rem',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    borderRadius: '4px',
+                    transition: 'all 0.2s',
+                    opacity: deletingGroupId === group.id ? 0.5 : 1,
+                  }}
+                  title="Delete category"
+                  onMouseEnter={(e) => e.currentTarget.style.background = 'var(--bg-card)'}
+                  onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
+                >
+                  <Trash2 size={14} />
+                </button>
                 <div
                   style={{
                     fontWeight: '600',
                     color: 'var(--text)',
                     marginBottom: '0.5rem',
+                    paddingRight: '1.5rem',
                   }}
                 >
                   {group.name} ({group.options.length} options)

--- a/src/components/navigation/BottomNav.jsx
+++ b/src/components/navigation/BottomNav.jsx
@@ -4,11 +4,11 @@ import { NavLink, useLocation } from 'react-router-dom';
 
 const BottomNav = ({ onLoadStatistics }) => {
   const items = [
-    { key: '', label: 'Home', icon: Home, end: true },
-    { key: 'goals', label: 'Goals', icon: Target },
-    { key: 'stats', label: 'Stats', icon: BarChart3 },
-    { key: 'achievements', label: 'Awards', icon: Trophy },
-    { key: 'settings', label: 'Settings', icon: Settings },
+    { key: '/dashboard', label: 'Home', icon: Home, end: true },
+    { key: '/dashboard/goals', label: 'Goals', icon: Target },
+    { key: '/dashboard/stats', label: 'Stats', icon: BarChart3 },
+    { key: '/dashboard/achievements', label: 'Awards', icon: Trophy },
+    { key: '/dashboard/settings', label: 'Settings', icon: Settings },
   ];
 
   const location = useLocation();

--- a/src/components/navigation/Sidebar.jsx
+++ b/src/components/navigation/Sidebar.jsx
@@ -4,10 +4,10 @@ import { NavLink, useLocation } from 'react-router-dom';
 
 const Sidebar = ({ onLoadStatistics }) => {
   const items = [
-    { key: '', label: 'Home', icon: Home, end: true },
-    { key: 'goals', label: 'Goals', icon: Target },
-    { key: 'stats', label: 'Statistics', icon: BarChart3 },
-    { key: 'achievements', label: 'Achievements', icon: Trophy },
+    { key: '/dashboard', label: 'Home', icon: Home, end: true },
+    { key: '/dashboard/goals', label: 'Goals', icon: Target },
+    { key: '/dashboard/stats', label: 'Statistics', icon: BarChart3 },
+    { key: '/dashboard/achievements', label: 'Achievements', icon: Trophy },
   ];
 
   const location = useLocation();
@@ -53,7 +53,7 @@ const Sidebar = ({ onLoadStatistics }) => {
 
         <div className="sidebar__footer">
           <NavLink
-            to="settings"
+            to="/dashboard/settings"
             className={({ isActive }) => `sidebar__item ${isActive ? 'is-active' : ''}`}
             title="Settings"
           >

--- a/src/hooks/useGroups.js
+++ b/src/hooks/useGroups.js
@@ -23,7 +23,7 @@ export const useGroups = () => {
 
   const createGroup = async (name) => {
     try {
-      await apiService.createGroup(name);
+      await apiService.createGroup({ name });
       await loadGroups(); // Refresh the list
       return true;
     } catch (error) {
@@ -35,7 +35,7 @@ export const useGroups = () => {
 
   const createGroupOption = async (groupId, name) => {
     try {
-      await apiService.createGroupOption(groupId, name);
+      await apiService.createGroupOption(groupId, { name });
       await loadGroups(); // Refresh the list
       return true;
     } catch (error) {

--- a/src/hooks/useStatistics.js
+++ b/src/hooks/useStatistics.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import apiService from '../services/api';
 
 export const useStatistics = () => {
@@ -7,10 +7,10 @@ export const useStatistics = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  const loadStatistics = async () => {
+  const loadStatistics = useCallback(async () => {
     setLoading(true);
     setError(null);
-    
+
     try {
       const data = await apiService.getStatistics();
       setStatistics(data);
@@ -20,9 +20,9 @@ export const useStatistics = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
-  const loadStreak = async () => {
+  const loadStreak = useCallback(async () => {
     try {
       const data = await apiService.getCurrentStreak();
       setCurrentStreak(data.current_streak);
@@ -30,7 +30,7 @@ export const useStatistics = () => {
       console.error('Failed to load streak:', error);
       setCurrentStreak(0);
     }
-  };
+  }, []);
 
   useEffect(() => {
     loadStreak();

--- a/src/views/EntryView.jsx
+++ b/src/views/EntryView.jsx
@@ -11,12 +11,13 @@ const DEFAULT_MARKDOWN = `# How was your day?
 
 Write about your thoughts, feelings, and experiences...`;
 
-const EntryView = ({ 
-  selectedMood, 
-  groups, 
-  onBack, 
-  onCreateGroup, 
-  onCreateOption, 
+const EntryView = ({
+  selectedMood,
+  groups,
+  onBack,
+  onCreateGroup,
+  onCreateOption,
+  onDeleteGroup,
   onEntrySubmitted,
   onSelectMood,
   editingEntry = null,
@@ -283,6 +284,7 @@ const EntryView = ({
               groups={groups}
               onCreateGroup={onCreateGroup}
               onCreateOption={onCreateOption}
+              onDeleteGroup={onDeleteGroup}
             />
           </div>
         </div>


### PR DESCRIPTION
### Added a couple bugfixes

1. We could not create new categories/groups because the frontend was sending a string to the API directly, instead of JSON
2. /api/statistics was being spammed on the statistics page (see commit info for details)
3. navigation was using relative paths which did weird things to the URL (like clicking Goals on sidebar twice goes to `/goals/goals`)

NOTE: 2 was pretty heavily vibe coded. From what I understood, the issue is that we were changing the the signature of loadStatistics by directly assigning it which was causing a recursive trigger of the `useEffect`. 

`useCallback` fixes this by implementing a cache for the function description and returns the same function reference if it is the same.
### Added a feature

1. I saw the function to delete categories but not a way to use it on the UI, so I added a trash icon similar to the Goals