### PR TITLE
Add burner mode vent entries

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import NotFound from "./views/NotFound";
 import { AuthProvider } from "./contexts/AuthContext";
 import { ConfigProvider, useConfig } from "./contexts/ConfigContext";
 import { ThemeProvider } from "./contexts/ThemeContext";
+import { BurnerProvider } from "./contexts/BurnerContext";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Header from "./components/Header";
 import Sidebar from "./components/navigation/Sidebar";
@@ -187,24 +188,26 @@ function App() {
   return (
     <ConfigProvider>
       <ThemeProvider>
-        <ToastProvider>
-          <AuthProvider>
-            <Routes>
-              <Route path="/" element={<LandingPage />} />
-              <Route path="/about" element={<AboutPage />} />
-              <Route path="/login" element={<LoginPage />} />
-              <Route
-                path="/dashboard/*"
-                element={
-                  <ProtectedRoute>
-                    <AppContent />
-                  </ProtectedRoute>
-                }
-              />
-              <Route path="*" element={<NotFound />} />
-            </Routes>
-          </AuthProvider>
-        </ToastProvider>
+        <BurnerProvider>
+          <ToastProvider>
+            <AuthProvider>
+              <Routes>
+                <Route path="/" element={<LandingPage />} />
+                <Route path="/about" element={<AboutPage />} />
+                <Route path="/login" element={<LoginPage />} />
+                <Route
+                  path="/dashboard/*"
+                  element={
+                    <ProtectedRoute>
+                      <AppContent />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </AuthProvider>
+          </ToastProvider>
+        </BurnerProvider>
       </ThemeProvider>
     </ConfigProvider>
   );

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -85,6 +85,12 @@
   justify-content: center;
 }
 
+.header__iconButton--active {
+  background: color-mix(in oklab, var(--accent-bg) 18%, transparent);
+  border-color: color-mix(in oklab, var(--accent-600) 55%, var(--border));
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--accent-600) 30%, transparent);
+}
+
 .header__profile {
   display: flex;
   align-items: center;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,6 +4,7 @@ import { Flame, LogOut, Sun, Moon } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { useConfig } from '../contexts/ConfigContext';
 import { useTheme } from '../contexts/ThemeContext';
+import { useBurner } from '../contexts/BurnerContext';
 import { useToast } from './ui/ToastProvider';
 import SearchPlaceholder from './search/SearchPlaceholder';
 
@@ -64,6 +65,7 @@ const Header = ({ currentStreak }) => {
   const { user, logout } = useAuth();
   useConfig();
   const { theme, cycle } = useTheme();
+  const { isBurnerMode, toggleBurnerMode } = useBurner();
   const { show } = useToast();
   const [showAvatar, setShowAvatar] = useState(true);
 
@@ -127,6 +129,17 @@ const Header = ({ currentStreak }) => {
               aria-label="Toggle theme"
             >
               {theme === 'dark' ? <Sun size={14} strokeWidth={2} /> : <Moon size={14} strokeWidth={2} />}
+            </button>
+
+            <button
+              type="button"
+              onClick={toggleBurnerMode}
+              className={`header__button header__iconButton${isBurnerMode ? ' header__iconButton--active' : ''}`}
+              title={`Burner mode: ${isBurnerMode ? 'on' : 'off'}`}
+              aria-label="Toggle burner mode"
+              aria-pressed={isBurnerMode}
+            >
+              <Flame size={14} strokeWidth={2} />
             </button>
 
             <div className="header__profile">

--- a/src/contexts/BurnerContext.jsx
+++ b/src/contexts/BurnerContext.jsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+const BurnerContext = createContext({
+  isBurnerMode: false,
+  setIsBurnerMode: () => {},
+  toggleBurnerMode: () => {},
+});
+
+export const BurnerProvider = ({ children }) => {
+  const [isBurnerMode, setIsBurnerMode] = useState(() => {
+    try {
+      return localStorage.getItem('nightlio:burner-mode') === 'on';
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('nightlio:burner-mode', isBurnerMode ? 'on' : 'off');
+    } catch {
+      // Ignore storage write failures.
+    }
+  }, [isBurnerMode]);
+
+  const value = useMemo(
+    () => ({
+      isBurnerMode,
+      setIsBurnerMode,
+      toggleBurnerMode: () => setIsBurnerMode((current) => !current),
+    }),
+    [isBurnerMode]
+  );
+
+  return <BurnerContext.Provider value={value}>{children}</BurnerContext.Provider>;
+};
+
+export const useBurner = () => useContext(BurnerContext);

--- a/src/views/EntryView.jsx
+++ b/src/views/EntryView.jsx
@@ -6,6 +6,7 @@ import GroupManager from '../components/groups/GroupManager';
 import MDArea from '../components/MarkdownArea.jsx';
 import apiService from '../services/api';
 import { useToast } from '../components/ui/ToastProvider';
+import { useBurner } from '../contexts/BurnerContext';
 
 const DEFAULT_MARKDOWN = `# How was your day?
 
@@ -32,6 +33,7 @@ const EntryView = ({
   const [showMoodPicker, setShowMoodPicker] = useState(false);
   const markdownRef = useRef();
   const { show } = useToast();
+  const { isBurnerMode } = useBurner();
 
   useEffect(() => {
     if (!isEditing || !editingEntry) return;
@@ -71,7 +73,29 @@ const EntryView = ({
     }
   };
 
+  const resetDraftComposer = () => {
+    markdownRef.current?.getInstance?.()?.setMarkdown(DEFAULT_MARKDOWN);
+    setSelectedOptions([]);
+    setSubmitMessage('');
+    setShowMoodPicker(false);
+  };
+
+  const handleCloseWriter = () => {
+    if (isBurnerMode && !isEditing) {
+      resetDraftComposer();
+    }
+
+    if (typeof onBack === 'function') {
+      onBack();
+    }
+  };
+
   const handleSubmit = async () => {
+    if (isBurnerMode) {
+      show('Burner mode is on. Close the writer when you are done venting.', 'info');
+      return;
+    }
+
     setIsSubmitting(true);
     setSubmitMessage('');
 
@@ -158,7 +182,7 @@ const EntryView = ({
       <div style={{ marginTop: '1rem' }}>
         <div style={{ marginBottom: '1rem' }}>
           <button
-            onClick={onBack}
+            onClick={handleCloseWriter}
             style={{
               padding: '0.5rem 1rem',
               background: 'var(--accent-bg)',
@@ -187,7 +211,7 @@ const EntryView = ({
     <div className="entry-container" style={{ marginTop: '1rem', position: 'relative' }}>
       <div style={{ marginBottom: '1rem' }}>
         <button
-          onClick={onBack}
+          onClick={handleCloseWriter}
           style={{
             padding: '0.5rem 1rem',
             background: 'var(--accent-bg)',
@@ -289,26 +313,44 @@ const EntryView = ({
 
         <div className="entry-right">
           <MDArea ref={markdownRef} />
-          <div className="entry-savebar">
-      <button
-              disabled={isSubmitting}
-              onClick={handleSubmit}
+          {isBurnerMode && (
+            <div
               style={{
-                padding: '0.9rem 2rem',
-                fontSize: '1rem',
-  background: 'linear-gradient(135deg, var(--accent-bg), var(--accent-bg-2))',
-                color: 'white',
-                border: 'none',
-                borderRadius: '50px',
-                cursor: !isSubmitting ? 'pointer' : 'not-allowed',
-                transition: 'all 0.3s ease',
-                fontWeight: '600',
-    boxShadow: 'var(--shadow-md)'
+                marginTop: '0.9rem',
+                padding: '0.85rem 1rem',
+                borderRadius: '14px',
+                border: '1px solid color-mix(in oklab, var(--accent-600) 36%, var(--border))',
+                background: 'color-mix(in oklab, var(--accent-bg-soft) 52%, transparent)',
+                color: 'var(--text)',
+                fontSize: '0.9rem',
+                lineHeight: 1.35,
               }}
             >
-              {isSubmitting ? 'Saving...' : isEditing ? 'Save Changes' : 'Save Entry'}
-            </button>
-          </div>
+              Burner mode is on. This vent entry is temporary and disappears when you close the writer.
+            </div>
+          )}
+          {!isBurnerMode && (
+            <div className="entry-savebar">
+              <button
+                disabled={isSubmitting}
+                onClick={handleSubmit}
+                style={{
+                  padding: '0.9rem 2rem',
+                  fontSize: '1rem',
+                  background: 'linear-gradient(135deg, var(--accent-bg), var(--accent-bg-2))',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: '50px',
+                  cursor: !isSubmitting ? 'pointer' : 'not-allowed',
+                  transition: 'all 0.3s ease',
+                  fontWeight: '600',
+                  boxShadow: 'var(--shadow-md)'
+                }}
+              >
+                {isSubmitting ? 'Saving...' : isEditing ? 'Save Changes' : 'Save Entry'}
+              </button>
+            </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
This pull request introduces a new "Burner Mode" feature, allowing users to create temporary vent entries that are not saved and are cleared when the writer is closed. The implementation includes a new context for managing burner mode state, UI updates to toggle and indicate burner mode, and logic changes to the entry view to support the temporary nature of burner entries.

**Burner Mode Feature Implementation:**

* Added a new `BurnerContext` with a provider and hook (`BurnerProvider`, `useBurner`) to manage burner mode state and persist it in `localStorage`. (`src/contexts/BurnerContext.jsx`)
* Wrapped the application in `BurnerProvider` to make burner mode state available throughout the app. (`src/App.jsx`) [[1]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R8) [[2]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R191) [[3]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R210)

**Header UI Updates:**

* Added a burner mode toggle button to the header, using the `Flame` icon, with visual feedback when active. (`src/components/Header.jsx`, `src/components/Header.css`) [[1]](diffhunk://#diff-8c468c347b974539dbc7411567675397475e1aeac509adf899831746084c1179R7) [[2]](diffhunk://#diff-8c468c347b974539dbc7411567675397475e1aeac509adf899831746084c1179R68) [[3]](diffhunk://#diff-8c468c347b974539dbc7411567675397475e1aeac509adf899831746084c1179R134-R144) [[4]](diffhunk://#diff-1489e74d856e9d4ef40cfb8adf2b7f8b8a53e0616377400d2cc82e3594f5d70eR88-R93)

**Entry View Logic and UI Changes:**

* Integrated burner mode awareness into `EntryView`, including:
  - Preventing entry submission in burner mode and showing an informational toast instead.
  - Resetting the draft composer when closing the writer in burner mode.
  - Displaying a notice that entries are temporary and not saved when burner mode is active.
  - Hiding the save bar when in burner mode. (`src/views/EntryView.jsx`) [[1]](diffhunk://#diff-8b3c9316ad29b8fb013803eb450f3b64778140cfd8c94b0ab68dcac30c300604R9) [[2]](diffhunk://#diff-8b3c9316ad29b8fb013803eb450f3b64778140cfd8c94b0ab68dcac30c300604R36) [[3]](diffhunk://#diff-8b3c9316ad29b8fb013803eb450f3b64778140cfd8c94b0ab68dcac30c300604R76-R98) [[4]](diffhunk://#diff-8b3c9316ad29b8fb013803eb450f3b64778140cfd8c94b0ab68dcac30c300604L161-R185) [[5]](diffhunk://#diff-8b3c9316ad29b8fb013803eb450f3b64778140cfd8c94b0ab68dcac30c300604L190-R214) [[6]](diffhunk://#diff-8b3c9316ad29b8fb013803eb450f3b64778140cfd8c94b0ab68dcac30c300604R316-R332) [[7]](diffhunk://#diff-8b3c9316ad29b8fb013803eb450f3b64778140cfd8c94b0ab68dcac30c300604R353)