### PR TITLE
Add PDF export engine

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -6,3 +6,4 @@ python-jose[cryptography]==3.3.0
 python-dotenv==1.0.0
 pytest==7.4.3
 gunicorn==21.2.0
+markdown-pdf==1.13.1

--- a/api/routes/misc_routes.py
+++ b/api/routes/misc_routes.py
@@ -1,5 +1,11 @@
 import time
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request, send_file
+import io
+try:
+    from markdown_pdf import MarkdownPdf, Section
+except ImportError:
+    MarkdownPdf = None
+    Section = None
 
 
 def create_misc_routes():
@@ -16,5 +22,30 @@ def create_misc_routes():
     @misc_bp.route("/time")
     def get_current_time():
         return {"time": time.time()}
+
+    @misc_bp.route("/export/pdf", methods=["POST"])
+    def export_pdf():
+        if not MarkdownPdf:
+            return jsonify({"error": "markdown-pdf module not installed"}), 501
+            
+        data = request.get_json()
+        if not data or "content" not in data:
+            return jsonify({"error": "Content is required"}), 400
+            
+        content = data.get("content", "")
+        
+        pdf = MarkdownPdf()
+        pdf.add_section(Section(content))
+        
+        out = io.BytesIO()
+        pdf.save(out)
+        out.seek(0)
+        
+        return send_file(
+            out,
+            mimetype="application/pdf",
+            as_attachment=True,
+            download_name="entry_export.pdf"
+        )
 
     return misc_bp

--- a/src/components/history/EntryModal.jsx
+++ b/src/components/history/EntryModal.jsx
@@ -1,6 +1,7 @@
 import ReactMarkdown from 'react-markdown';
-import { useEffect } from 'react';
-import { Pencil, Trash2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Pencil, Trash2, Download } from 'lucide-react';
+import apiService from '../../services/api';
 
 const backdropStyle = {
   position: 'fixed',
@@ -47,6 +48,8 @@ const deriveTitleBody = (content = '') => {
 };
 
 const EntryModal = ({ isOpen, entry, onClose, onDelete, isDeleting, onEdit }) => {
+  const [isExporting, setIsExporting] = useState(false);
+
   useEffect(() => {
     if (!isOpen) return;
     const onKeyDown = (e) => {
@@ -64,6 +67,29 @@ const EntryModal = ({ isOpen, entry, onClose, onDelete, isDeleting, onEdit }) =>
   const onBackdrop = (e) => {
     if (e.target === e.currentTarget) onClose();
   };
+
+  const handleExport = async (e) => {
+    e.stopPropagation();
+    if (isExporting) return;
+    setIsExporting(true);
+    try {
+      const blob = await apiService.exportPdf(entry.content);
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `Entry_${entry.date || 'Export'}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    } catch (err) {
+      console.error("Export error:", err);
+      alert("Failed to export PDF.");
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
   const { title, body } = deriveTitleBody(entry.content);
   return (
     <div style={backdropStyle} onClick={onBackdrop} role="dialog" aria-modal="true">
@@ -78,6 +104,28 @@ const EntryModal = ({ isOpen, entry, onClose, onDelete, isDeleting, onEdit }) =>
             )}
           </div>
           <div style={{ display: 'flex', gap: 8 }}>
+            <button
+              onClick={handleExport}
+              disabled={isExporting}
+              style={{
+                background: 'var(--surface)',
+                color: 'var(--text)',
+                border: '1px solid var(--border)',
+                borderRadius: 10,
+                padding: '8px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontWeight: 600,
+                boxShadow: 'var(--shadow-sm)',
+                opacity: isExporting ? 0.5 : 1,
+                cursor: isExporting ? 'not-allowed' : 'pointer',
+              }}
+              title="Export as PDF"
+              aria-label="Export as PDF"
+            >
+              <Download size={18} />
+            </button>
             {onEdit && (
               <button
                 onClick={(e) => { e.stopPropagation(); onEdit(); }}

--- a/src/components/history/EntryModal.jsx
+++ b/src/components/history/EntryModal.jsx
@@ -2,6 +2,7 @@ import ReactMarkdown from 'react-markdown';
 import { useEffect, useState } from 'react';
 import { Pencil, Trash2, Download } from 'lucide-react';
 import apiService from '../../services/api';
+import { getMoodLabel } from '../../utils/moodUtils';
 
 const backdropStyle = {
   position: 'fixed',
@@ -73,7 +74,27 @@ const EntryModal = ({ isOpen, entry, onClose, onDelete, isDeleting, onEdit }) =>
     if (isExporting) return;
     setIsExporting(true);
     try {
-      const blob = await apiService.exportPdf(entry.content);
+      const timeStr = entry.created_at ? new Date(entry.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '';
+      const dateStr = `${entry.date}${timeStr ? ` at ${timeStr}` : ''}`;
+      
+      const moodLabel = entry.mood ? getMoodLabel(entry.mood) : '';
+      
+      const tagsStr = entry.selections?.length > 0 
+        ? entry.selections.map(s => s.name).join(', ') 
+        : '';
+    
+      const headerLines = [];
+      headerLines.push(`**Date:** ${dateStr}`);
+      if (moodLabel) {
+        headerLines.push(`**Mood:** ${moodLabel}`);
+      }
+      if (tagsStr) {
+        headerLines.push(`**Tags:** ${tagsStr}`);
+      }
+    
+      const enhancedContent = headerLines.join('\n') + '\n\n---\n\n' + (entry.content || '');
+
+      const blob = await apiService.exportPdf(enhancedContent);
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -257,6 +257,34 @@ class ApiService {
     const q = params.toString();
     return this.request(`/api/goals/${goalId}/completions${q ? `?${q}` : ''}`);
   }
+
+  // Export endpoint
+  async exportPdf(content) {
+    const endpoint = '/api/export/pdf';
+    const base = API_BASE_URL;
+    let url;
+    if (!base) url = endpoint;
+    else if (/^https?:\/\//i.test(base)) url = `${base}${endpoint}`;
+    else url = `${base.replace(/\/+$/g, '')}${endpoint}`;
+    
+    const config = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content }),
+    };
+
+    if (this.token) {
+      config.headers.Authorization = `Bearer ${this.token}`;
+    }
+
+    const response = await fetch(url, config);
+    if (!response.ok) {
+      throw new Error(`Export failed: ${response.status}`);
+    }
+    return response.blob();
+  }
 }
 
 const apiService = new ApiService();


### PR DESCRIPTION
This pull request adds a new feature that allows users to export journal entries as PDFs. The export functionality is implemented end-to-end, including backend support for PDF generation from Markdown content and a frontend button for users to trigger the export. Supporting code and dependencies were also updated to enable this feature.

**PDF Export Feature**

_Backend Implementation:_
- Added the `markdown-pdf` dependency to `api/requirements.txt` to support PDF generation from Markdown content.
- Updated `api/routes/misc_routes.py` to add a new `/api/export/pdf` POST endpoint. This endpoint receives Markdown content, generates a PDF using `markdown-pdf`, and returns the PDF as a downloadable file. Graceful error handling is included if the dependency is missing or the request is malformed. [[1]](diffhunk://#diff-8ad842c3aa7a0be0d5243c3bc26fb4f0cc7b82732af0193e0193aa341cc5d6efL2-R8) [[2]](diffhunk://#diff-8ad842c3aa7a0be0d5243c3bc26fb4f0cc7b82732af0193e0193aa341cc5d6efR26-R50)

_Frontend Integration:_
- Added an `exportPdf` method to `apiService` in `src/services/api.js` to call the new backend endpoint and handle the PDF download.
- Updated `EntryModal.jsx` to include an "Export as PDF" button. When clicked, this button formats the entry content (including date, mood, and tags) as Markdown, sends it to the backend, and triggers a PDF download. The UI provides feedback during the export process and handles errors gracefully. [[1]](diffhunk://#diff-d0a49f2501a1833886bd685cd9f9e53e391ec785bf11a1cdb94ee6df68407ac1L2-R5) [[2]](diffhunk://#diff-d0a49f2501a1833886bd685cd9f9e53e391ec785bf11a1cdb94ee6df68407ac1R52-R53) [[3]](diffhunk://#diff-d0a49f2501a1833886bd685cd9f9e53e391ec785bf11a1cdb94ee6df68407ac1R71-R113) [[4]](diffhunk://#diff-d0a49f2501a1833886bd685cd9f9e53e391ec785bf11a1cdb94ee6df68407ac1R128-R149)