### PR TITLE
Remove unused requests package

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,7 +1,6 @@
 Flask==3.0.0
 flask-cors==4.0.0
 authlib==1.3.0
-requests==2.31.0
 python-jose[cryptography]==3.3.0
 python-dotenv==1.0.0
 pytest==7.4.3


### PR DESCRIPTION
This pull request makes a minor update to the project dependencies by removing the `requests` library from the `api/requirements.txt` file. This change likely reflects that `requests` is no longer needed as a dependency.

- Removed the `requests` package from the list of required dependencies in `api/requirements.txt`.